### PR TITLE
Add tailored AnaSol class

### DIFF
--- a/Test/Cube.xinp
+++ b/Test/Cube.xinp
@@ -21,12 +21,8 @@
   <!-- Problem-specific block !-->
   <poisson>
     <source type="expression">3*PI*PI*sin(x*PI)*sin(y*PI)*sin(z*PI)</source>
-    <anasol type="expression">
+    <anasol type="expression" autodiff="true">
       <primary>sin(PI*x)*sin(PI*y)*sin(z*PI)</primary>
-      <secondary>-PI*cos(PI*x)*sin(PI*y)*sin(z*PI) |
-                 -PI*sin(PI*x)*cos(PI*y)*sin(PI*z) |
-                 -PI*sin(PI*x)*sin(PI*y)*cos(PI*z)
-      </secondary>
     </anasol>
   </poisson>
 

--- a/Test/exact_p3_2D.xinp
+++ b/Test/exact_p3_2D.xinp
@@ -29,9 +29,8 @@
   <!-- Problem-specific block !-->
   <poisson>
     <source type="expression">-6.0*x*y*(x*x + y*y)</source>
-    <anasol type="expression">
+    <anasol type="expression" autodiff="true">
       <primary>x*x*x * y*y*y</primary>
-      <secondary>-3.0 * x*x * y*y*y | -3.0 * x*x*x * y*y</secondary>
     </anasol>
     <reactions/>
   </poisson>


### PR DESCRIPTION
To allow use of AD/FD to obtain the secondary solution. In particular we have to adjust for the inflow orientation.

Downstream of https://github.com/OPM/IFEM/pull/649