### PR TITLE
Changed: Restore Line regression results to pre 2016 values

### DIFF
--- a/Test/Line-subdivision.reg
+++ b/Test/Line-subdivision.reg
@@ -4,10 +4,10 @@ Number of elements    8
 Number of nodes       11
 Number of dofs        11
 Number of unknowns    10
-L2-norm            : 0.710286
-Max displacement   : 1
-Energy norm           a(u^h,u^h)^0.5 : 1.11072
-External energy          (h,u^h)^0.5 : 1.11072
-Exact norm                a(u,u)^0.5 : 1.11072
-Exact error      a(e,e)^0.5, e=u-u^h : 4.63905e-05
-Exact relative error (%) : 0.00417661
+L2-norm            : 0.621255
+Max displacement   : 1.02607
+Energy norm           a(u^h,u^h)^0.5 : 1.5708
+External energy          (h,u^h)^0.5 : 1.5708
+Exact norm                a(u,u)^0.5 : 1.5708
+Exact error      a(e,e)^0.5, e=u-u^h : 0.000567369
+Exact relative error (%) : 0.0361198

--- a/Test/Line.reg
+++ b/Test/Line.reg
@@ -4,17 +4,17 @@ Number of elements    8
 Number of nodes       11
 Number of dofs        11
 Number of unknowns    10
-L2-norm            : 0.710286
-Max displacement   : 1
-Energy norm           a(u^h,u^h)^0.5 : 1.11072
-External energy          (h,u^h)^0.5 : 1.11072
-Exact norm                a(u,u)^0.5 : 1.11072
-Exact error      a(e,e)^0.5, e=u-u^h : 4.63905e-05
-Exact relative error (%) : 0.00417661
-VCP quantity                a(u^h,w) : -0.994904
-VCP quantity                  a(u,w) : -0.994903
-Vol(D) : 0.125
-  Point #1:	sol1 =  7.730e-01
-		exact1 -7.730e-01
-		sol2 = -9.965e-01
-		exact2 -9.965e-01
+L2-norm            : 0.621255
+Max displacement   : 1.02607
+Energy norm           a(u^h,u^h)^0.5 : 1.5708
+External energy          (h,u^h)^0.5 : 1.5708
+Exact norm                a(u,u)^0.5 : 1.5708
+Exact error      a(e,e)^0.5, e=u-u^h : 0.000567369
+Exact relative error (%) : 0.0361198
+VCP quantity                a(u^h,w) : 0.304495
+VCP quantity                  a(u,w) : 0.304482
+Vol(D) : 0.25
+  Point #1:	sol1 =  9.808e-01
+		exact1 -9.808e-01
+		sol2 =  3.065e-01
+		exact2  3.064e-01

--- a/Test/Sinus2D.reg
+++ b/Test/Sinus2D.reg
@@ -6,10 +6,7 @@ Number of Gauss points: 4
 Parsing input file Sinus2D.xinp
 Parsing <discretization>
 Parsing <geometry>
-  Using 2D multi-patch model generator.
-	Split in X = 1
-	Split in Y = 1
-	Reading patch 1
+  Generating linear geometry on unit parameter domain \[0,1]^2
   Parsing <raiseorder>
   Parsing <refine>
   Parsing <topologysets>


### PR DESCRIPTION
as this is the correct solution when the Length parameter is back.
The old results were for L=1 which is misleading with the input files.

Downstreams of OPM/IFEM#743